### PR TITLE
Gate BOOST_ASIO_DISABLE_* macros behind boost_asio_legacy_abi option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,10 +10,12 @@ project(
   ]
 )
 
-add_project_arguments('-DBOOST_ASIO_DISABLE_MOVE', language : 'cpp')
-add_project_arguments('-DBOOST_ASIO_DISABLE_STD_ARRAY', language : 'cpp')
-add_project_arguments('-DBOOST_ASIO_DISABLE_STD_ATOMIC', language : 'cpp')
-add_project_arguments('-DBOOST_ASIO_DISABLE_STD_CHRONO', language : 'cpp')
+if get_option('boost_asio_legacy_abi')
+  add_project_arguments('-DBOOST_ASIO_DISABLE_MOVE', language : 'cpp')
+  add_project_arguments('-DBOOST_ASIO_DISABLE_STD_ARRAY', language : 'cpp')
+  add_project_arguments('-DBOOST_ASIO_DISABLE_STD_ATOMIC', language : 'cpp')
+  add_project_arguments('-DBOOST_ASIO_DISABLE_STD_CHRONO', language : 'cpp')
+endif
 
 dependencies = [
   dependency('threads'),

--- a/meson.options
+++ b/meson.options
@@ -1,1 +1,2 @@
 option('docs', type : 'boolean', value : false, description : 'generate documentation')
+option('boost_asio_legacy_abi', type : 'boolean', value : false, yield : true, description : 'Define legacy BOOST_ASIO_DISABLE_* macros for Boost.Asio ABI compat.')


### PR DESCRIPTION
## Problem

The four `-DBOOST_ASIO_DISABLE_*` macros change the ABI/layout of Boost.Asio internal types (scheduler, io_context). Boost.Asio is header-only, so these are compiled per translation unit.

When libmcache is deep-built into a single binary alongside **libmime** — which since v2.2.10 gates the same macros behind a `boost_asio_legacy_abi` option (default **off** = modern ABI) — libmcache's unconditional definitions force a **legacy** asio ABI while libmime uses the **modern** one. Linking both into one binary produces an **ODR violation**: same-named asio symbols with incompatible layouts get merged, and mcache code ends up reading uninitialised asio scheduler fields (surfaces under valgrind as "Conditional jump or move depends on uninitialised value(s)" in the memcache connect path, and as a hang without valgrind).

## Fix

Gate the macros behind a yielding `boost_asio_legacy_abi` option (default **off** = modern ABI), mirroring libmime's mechanism. A parent project can then select one consistent asio ABI for all subprojects.

No behavioural change for standalone builds of libmcache (default stays modern). Consumers needing the legacy ABI can set `boost_asio_legacy_abi=true`.